### PR TITLE
[BUG FIX] Problema ao ler valor de clipboard no Firefox

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -104,5 +104,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/app/pages/cifra/cifra.component.html
+++ b/src/app/pages/cifra/cifra.component.html
@@ -11,14 +11,14 @@
                 <li><a class="dropdown-item" (click)="gerarChaveComFraseAleatoria()">Frase aleatória</a></li>
             </ul>
         </div>
-        <p><a (click)="copiarChave()">{{ chave.trim() ? 'Copiar chave' : ''}}</a></p>
+        <p><a *ngIf="canSaveValueOnClipboard && chave.trim()" (click)="copiarChave()">Copiar chave</a></p>
     </div>
-    
+
     <div class="mb-4">
         <label for="mensagem" class="form-label">Mensagem</label>
         <textarea class="form-control" id="mensagem" rows="10" [(ngModel)]="mensagem" required (change)="onChangeMensagem()"></textarea>
         <div class="row">
-            <div class="col"><p><a (click)="colarTexto()">Colar texto</a></p></div>
+            <div class="col"><p><a *ngIf="canReadValueFromClipboard" (click)="colarTexto()">Colar texto</a></p></div>
             <div class="col"><p class="text-end">{{ mensagem.length > 0 ? mensagem.length : '' }}</p></div>
         </div>
     </div>
@@ -35,7 +35,7 @@
             </div>
         </div>
     </div>
-    
+
     <div class="row">
         <div class="col">
             <button type="button" class="btn btn-primary me-2 mt-2" (click)="criptografar()">Criptografar</button>

--- a/src/app/pages/cifra/cifra.component.scss
+++ b/src/app/pages/cifra/cifra.component.scss
@@ -4,3 +4,7 @@ ul.list-unstyled {
         margin: 5px;
     }
 }
+
+p {
+  height: 30px;
+}

--- a/src/app/pages/cifra/cifra.component.ts
+++ b/src/app/pages/cifra/cifra.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 
 import { CifraDeVigenereService } from '../../services/cifra-de-vigenere/cifra-de-vigenere.service';
 import { UtilService } from 'src/app/services/util/util.service';
-import { copy } from 'clipboard';
+import { ClipboardService } from 'src/app/services/clip-board/clipboard.service';
 
 @Component({
   selector: 'app-cifra',
@@ -22,7 +22,10 @@ export class CifraComponent {
   dangerAlerts: string[];
   infoAlerts: string[];
 
-  constructor (private cifraDeVigenere: CifraDeVigenereService, private util: UtilService) {
+  canReadValueFromClipboard: boolean;
+  canSaveValueOnClipboard: boolean;
+
+  constructor (private cifraDeVigenere: CifraDeVigenereService, private util: UtilService, private clipboard: ClipboardService) {
     this.chave = this.util.getUtilCache('chave') ?? '';
     this.mensagem = this.util.getUtilCache('mensagem') ?? '';
     this.resultado = '';
@@ -32,6 +35,9 @@ export class CifraComponent {
     this.waringAlerts = [];
     this.dangerAlerts = [];
     this.infoAlerts = [];
+
+    this.canReadValueFromClipboard = clipboard.canReadValueFromClipboard();
+    this.canSaveValueOnClipboard = clipboard.canSaveValueOnClipboard();
   }
 
   onChangeChave():void {
@@ -82,13 +88,17 @@ export class CifraComponent {
   }
 
   copiarChave():void {
-    copy(this.chave);
+    if (this.canSaveValueOnClipboard) {
+      this.clipboard.saveValueOnClipboard(this.chave);
+    }
   }
 
   colarTexto():void {
-    navigator['clipboard'].readText().then((data) => {
-      this.mensagem = data;
-    });
+    if (this.canReadValueFromClipboard) {
+      this.clipboard.readValueFromClipboard((value) => {
+        this.mensagem = value;
+      });
+    }
   }
 
   limpar() {
@@ -111,12 +121,12 @@ export class CifraComponent {
     const caracteres = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
     const comprimento = 30;
     let chave = '';
-  
+
     for (let i = 0; i < comprimento; i++) {
       let indice = Math.floor(Math.random() * caracteres.length);
       chave += caracteres.charAt(indice);
     }
-  
+
     this.chave = chave;
   }
 

--- a/src/app/services/clip-board/clipboard.service.spec.ts
+++ b/src/app/services/clip-board/clipboard.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ClipboardService } from './clipboard.service';
+
+describe('ClipboardService', () => {
+  let service: ClipboardService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ClipboardService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/clip-board/clipboard.service.ts
+++ b/src/app/services/clip-board/clipboard.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { copy } from 'clipboard';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ClipboardService {
+
+  readValueFromClipboard(callback: (value: string) => void):void {
+    navigator['clipboard'].readText().then((value) => {
+      callback(value);
+    });
+  }
+
+  canReadValueFromClipboard():boolean {
+    if (!navigator['clipboard']) {
+      return false;
+    }
+    return !!navigator['clipboard'].readText;
+  }
+
+  saveValueOnClipboard(value: string):void {
+    copy(value);
+  }
+
+  canSaveValueOnClipboard():boolean {
+    return !!copy;
+  }
+
+}


### PR DESCRIPTION
Esse PR resolve o problema descrito na issue #1, onde o método de colar texto no campo Mensagem não funciona no Firefox.

Aparentemente o Firefox atualmente não é compatível com a função de *ler* valores copiados, apenas *gravar*. Então a minha solução foi remover os botões `Copiar chave` e `Colar texto` do formulário principal sempre que a função de copiar ou colar não estiver disponível.

Para isso criei o novo service `ClipboardService` com os seguintes métodos:
- `readValueFromClipboard(callback: (value: string) => void):void`: Lê texto do clipboard. Recebe um callback que deverá lidar com o valor previamente copiado.
- `canReadValueFromClipboard():boolean`: Verifica se a função de ler texto de clipboard está disponível
- `saveValueOnClipboard(value: string):void`: Salva texto no clipboard. Recebe como parâmetro uma string com o valor a ser salvo
- `canSaveValueOnClipboard():boolean`: Verifica se a função de salvar texto no clipboard está disponível